### PR TITLE
Enforce python3 and fix paths error

### DIFF
--- a/code/submit_dataset_info.py
+++ b/code/submit_dataset_info.py
@@ -2,9 +2,19 @@
 # since descriptions might well contain commata, the resulting csv is tab-separated
 
 from pandas import read_csv
+import sys
+
+if sys.version_info[0] < 3:
+    raise Exception("Python 3 is required.")
 
 # load old data so we can check for duplicates
-old_data = read_csv('../data/overview_of_datasets.csv', sep='\t')
+# this try-except is horrible and needs to be replaced by a better way of dealing with paths
+try:
+    old_data = read_csv('../data/overview_of_datasets.csv', sep='\t')
+    data_path = '../data/overview_of_datasets.csv'
+except IOError:
+    old_data = read_csv('data/overview_of_datasets.csv', sep='\t')
+    data_path = 'data/overview_of_datasets.csv'
 
 name = input('Name of the dataset:\n')
 while name == '':
@@ -31,7 +41,7 @@ license = input('Dataset license:\n')
 other = input('Any other information about the dataset:\n')
 
 csv_row = '\t'.join([name, status, source, description, license]) + '\n'
-with open('../data/overview_of_datasets.csv','a') as f:
+with open(data_path,'a') as f:
      f.write(csv_row)
 
 print('Success!')


### PR DESCRIPTION
- python2 has different `input` behaviour so python3 needs to be enforced
- script could only be run from `code` directory, now can be run from top

todo: use a proper solution for the relative file path